### PR TITLE
Display gathering node icons based on GatheringInvisible

### DIFF
--- a/FFXIVAPP.Plugin.Radar/Controls/Radar.xaml.cs
+++ b/FFXIVAPP.Plugin.Radar/Controls/Radar.xaml.cs
@@ -572,7 +572,7 @@ namespace FFXIVAPP.Plugin.Radar.Controls
                                     sb.AppendFormat(" {0:N2} {1}", user.GetDistanceTo(actorEntity), ResolveHeightVariance(user, actorEntity));
                                 }
                                 var actorIcon = RadarIconHelper.Wood;
-                                if (actorEntity.HPCurrent > 0)
+                                if (actorEntity.GatheringInvisible == 0)
                                 {
                                     drawingContext.DrawImage(actorIcon, new Rect(new Point(screen.X, screen.Y), new Size(16, 16)));
                                 }


### PR DESCRIPTION
ActorEntity object is much smaller for gathering nodes, and does not extend to HPCurrent.